### PR TITLE
feat: add reusable game module

### DIFF
--- a/games/chase-hard.html
+++ b/games/chase-hard.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Fast Enemy</title>
+</head>
+<body>
+  <canvas id="game" width="500" height="500"></canvas>
+  <script type="module">
+    import { startGame } from './common.js';
+    startGame({ canvas: document.getElementById('game'), enemySpeed: 4 });
+  </script>
+</body>
+</html>

--- a/games/chase.html
+++ b/games/chase.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Chase Game</title>
+</head>
+<body>
+  <canvas id="game" width="500" height="500"></canvas>
+  <script type="module">
+    import { startGame } from './common.js';
+    startGame({ canvas: document.getElementById('game') });
+  </script>
+</body>
+</html>

--- a/games/common.js
+++ b/games/common.js
@@ -1,0 +1,53 @@
+export function startGame({
+  canvas,
+  playerColor = 'blue',
+  enemyColor = 'red',
+  playerSpeed = 5,
+  enemySpeed = 2
+}) {
+  const ctx = canvas.getContext('2d');
+  const player = { x: canvas.width / 2, y: canvas.height / 2 };
+  const enemy = { x: 20, y: 20 };
+  const keys = {};
+
+  window.addEventListener('keydown', e => {
+    keys[e.key] = true;
+  });
+
+  window.addEventListener('keyup', e => {
+    keys[e.key] = false;
+  });
+
+  function update() {
+    if (keys.ArrowUp) player.y -= playerSpeed;
+    if (keys.ArrowDown) player.y += playerSpeed;
+    if (keys.ArrowLeft) player.x -= playerSpeed;
+    if (keys.ArrowRight) player.x += playerSpeed;
+
+    const dx = player.x - enemy.x;
+    const dy = player.y - enemy.y;
+    const len = Math.hypot(dx, dy);
+    if (len > 0) {
+      enemy.x += (enemySpeed * dx) / len;
+      enemy.y += (enemySpeed * dy) / len;
+    }
+  }
+
+  function draw() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.fillStyle = playerColor;
+    ctx.fillRect(player.x - 10, player.y - 10, 20, 20);
+    ctx.fillStyle = enemyColor;
+    ctx.fillRect(enemy.x - 10, enemy.y - 10, 20, 20);
+  }
+
+  function loop() {
+    update();
+    draw();
+    requestAnimationFrame(loop);
+  }
+
+  loop();
+
+  return { player, enemy };
+}


### PR DESCRIPTION
## Summary
- add `games/common.js` for canvas, movement and chasing logic
- replace inline scripts with module imports in example game pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892a712da5083249c3967c0474082ef