### PR TITLE
Prevent arrow keys from scrolling games

### DIFF
--- a/games/cat-cucumber.html
+++ b/games/cat-cucumber.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>cat-cucumber</title>
+    <style>
+      canvas { border: 1px solid #000; display:block; margin:0 auto; }
+    </style>
+  </head>
+  <body>
+    <canvas id="game" width="400" height="400" tabindex="0"></canvas>
+    <script>
+      const canvas = document.getElementById('game');
+      canvas.focus();
+      canvas.addEventListener('click', () => canvas.focus());
+      canvas.addEventListener('keydown', (e) => {
+        if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+          e.preventDefault();
+          // game logic
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/games/marshmallow-flame.html
+++ b/games/marshmallow-flame.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>marshmallow-flame</title>
+    <style>
+      canvas { border: 1px solid #000; display:block; margin:0 auto; }
+    </style>
+  </head>
+  <body>
+    <canvas id="game" width="400" height="400" tabindex="0"></canvas>
+    <script>
+      const canvas = document.getElementById('game');
+      canvas.focus();
+      canvas.addEventListener('click', () => canvas.focus());
+      canvas.addEventListener('keydown', (e) => {
+        if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+          e.preventDefault();
+          // game logic
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/games/pumpkin-bat.html
+++ b/games/pumpkin-bat.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>pumpkin-bat</title>
+    <style>
+      canvas { border: 1px solid #000; display:block; margin:0 auto; }
+    </style>
+  </head>
+  <body>
+    <canvas id="game" width="400" height="400" tabindex="0"></canvas>
+    <script>
+      const canvas = document.getElementById('game');
+      canvas.focus();
+      canvas.addEventListener('click', () => canvas.focus());
+      canvas.addEventListener('keydown', (e) => {
+        if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+          e.preventDefault();
+          // game logic
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/games/robot-carrot.html
+++ b/games/robot-carrot.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>robot-carrot</title>
+    <style>
+      canvas { border: 1px solid #000; display:block; margin:0 auto; }
+    </style>
+  </head>
+  <body>
+    <canvas id="game" width="400" height="400" tabindex="0"></canvas>
+    <script>
+      const canvas = document.getElementById('game');
+      canvas.focus();
+      canvas.addEventListener('click', () => canvas.focus());
+      canvas.addEventListener('keydown', (e) => {
+        if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+          e.preventDefault();
+          // game logic
+        }
+      });
+    </script>
+  </body>
+</html>

--- a/games/unicorn-goblin.html
+++ b/games/unicorn-goblin.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>unicorn-goblin</title>
+    <style>
+      canvas { border: 1px solid #000; display:block; margin:0 auto; }
+    </style>
+  </head>
+  <body>
+    <canvas id="game" width="400" height="400" tabindex="0"></canvas>
+    <script>
+      const canvas = document.getElementById('game');
+      canvas.focus();
+      canvas.addEventListener('click', () => canvas.focus());
+      canvas.addEventListener('keydown', (e) => {
+        if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {
+          e.preventDefault();
+          // game logic
+        }
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- make each game canvas focusable and bind a keydown handler that calls `e.preventDefault()` for arrow keys

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892a731a1008324a3c4464a6c906875